### PR TITLE
Refactored authentication

### DIFF
--- a/client/Page/Admin/Settings/Partials/ConnectButton.tsx
+++ b/client/Page/Admin/Settings/Partials/ConnectButton.tsx
@@ -9,8 +9,8 @@ export default function ConnectButton() {
 
   async function connect() {
     setConnecting( true );
-    const connect_url = await tryRequest( 'get', 'oauth_connect' );
-    window.location = connect_url.data.data.url;
+    const { data } = await tryRequest( 'get', 'oauth_connect' );
+    window.location = data.url;
   }
 
   return (

--- a/client/Page/Admin/Settings/Partials/ManualAwpActivation.tsx
+++ b/client/Page/Admin/Settings/Partials/ManualAwpActivation.tsx
@@ -6,8 +6,8 @@ import { usePage } from '@/Providers/PageProvider';
 import { useRestRequest } from '@/Providers/RestRequestProvider';
 
 export function ManualAwpActivation() {
-  const { restReq, tryRequest } = useRestRequest();
-  const { page } = usePage();
+  const { tryRequest } = useRestRequest();
+  const { page, getApiUrl } = usePage();
 
   const [ fieldsVisible, setFieldsVisible ] = useState( false );
   const [ apiKey, setApiKey ] = useState( '' );
@@ -23,7 +23,7 @@ export function ManualAwpActivation() {
   async function saveManualToken( event: FormEvent< HTMLFormElement > ) {
     event.preventDefault();
 
-    const data = await tryRequest(
+    const res = await tryRequest< { settings: any[] } >(
       'post',
       'manual_activation',
       { apiKey },
@@ -37,9 +37,9 @@ export function ManualAwpActivation() {
       },
     );
 
-    if ( ! data.data?.success ) {
-      setServerErrors( { ...serverErrors, apiKey: data.data.message } );
-      console.error( data.data.message );
+    if ( ! res.success ) {
+      setServerErrors( { ...serverErrors, apiKey: '' } );
+      console.error( res.message );
     } else {
       document.location.reload();
     }
@@ -71,7 +71,7 @@ export function ManualAwpActivation() {
                 target="_blank"
                 className="underline"
                 // prettier-ignore
-                href={`${page.api_host}/manually_connect_site?url=${encodeURIComponent(page.home_url)}`}>
+                href={`${getApiUrl('oauthManuallyConnectSite')}?url=${encodeURIComponent(page.home_url)}`}>
                 Get your api key
               </a>
             }></Textarea>

--- a/client/Page/Admin/Settings/SubPages/SettingsTab.tsx
+++ b/client/Page/Admin/Settings/SubPages/SettingsTab.tsx
@@ -28,14 +28,14 @@ export default function SettingsTab() {
    */
   async function authorize() {
     setAuthorizing( true );
-    const authorize_url = await tryRequest( 'get', 'oauth_authorize' );
-    window.location = authorize_url.data.url;
+    const { data } = await tryRequest( 'get', 'oauth_authorize' );
+    window.location = data.url;
   }
 
   async function connect() {
     setConnecting( true );
-    const connect_url = await tryRequest( 'get', 'oauth_connect' );
-    window.location = connect_url.data.url;
+    const { data } = await tryRequest( 'get', 'oauth_connect' );
+    window.location = data.url;
   }
 
   function disconnect() {

--- a/client/Page/Admin/Settings/SubPages/UsersManagement.tsx
+++ b/client/Page/Admin/Settings/SubPages/UsersManagement.tsx
@@ -13,7 +13,7 @@ export default function UsersManagement() {
   const [ searching, setSearching ] = useState( false );
 
   async function getUsers() {
-    const response = await tryRequest(
+    const { data } = await tryRequest(
       'get',
       'agentwp_users',
       null,
@@ -21,7 +21,7 @@ export default function UsersManagement() {
       () => setSearching( false ),
     );
 
-    setUsers( response.data.data );
+    setUsers( data );
     setSearching( false );
   }
 

--- a/client/Page/Admin/Settings/Wizard.tsx
+++ b/client/Page/Admin/Settings/Wizard.tsx
@@ -4,9 +4,10 @@ import { useEffect, useState } from 'react';
 import UserAccess from '@/Page/Admin/Settings/Wizard/UserAccess';
 import { usePage } from '@/Providers/PageProvider';
 import { useRestRequest } from '@/Providers/RestRequestProvider';
+import type { SettingsPageData } from '@/Types/types';
 
 export default function Wizard() {
-  const { page } = usePage();
+  const { page } = usePage< SettingsPageData >();
   const { restReq } = useRestRequest();
 
   const [ steps, setSteps ] = useState( [
@@ -27,10 +28,6 @@ export default function Wizard() {
     },
   ] );
 
-  function isConnected() {
-    return ! page.account?.errors;
-  }
-
   function goToAboutPage() {
     restReq.post( `onboarding_completed` ).then( () => {
       document.location.reload();
@@ -38,7 +35,7 @@ export default function Wizard() {
   }
 
   useEffect( () => {
-    if ( isConnected() ) {
+    if ( page.is_connected ) {
       setSteps( [
         {
           text: 'Install Plugin',

--- a/client/Providers/PageProvider.tsx
+++ b/client/Providers/PageProvider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, ReactNode } from 'react';
 import type { PageData } from '@/Types/types';
+import routes from '../../server/Modules/AwpClient/routes.json';
+import { get } from 'http';
 
 // Define a generic type that extends PageData
 interface PageProviderProps< T extends PageData > {
@@ -14,6 +16,7 @@ interface PageContextType< T extends PageData > {
   isPage: ( pageContains: string ) => boolean;
   getAccountSetting: ( name: App.Enums.SiteSettingValue, defaultValue: any ) => any;
   userProfileUrl: string;
+  getApiUrl: ( name: string ) => string;
 }
 
 // Create a context with the generic type
@@ -28,6 +31,15 @@ export function usePage< T extends PageData >() {
   return context; // Directly return the context since it holds the generic page
 }
 
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+type Route = {
+  key: string;
+  name: string;
+  methods: HttpMethod[];
+  uri: string;
+};
+
 // Update the PageProvider to pass the generic type
 export function PageProvider< T extends PageData >( { page, children }: PageProviderProps< T > ) {
   const canAccessAgent = page.onboarding_completed && page.agentwp_access;
@@ -38,6 +50,14 @@ export function PageProvider< T extends PageData >( { page, children }: PageProv
     const currentPage = window.location.href;
     return currentPage.indexOf( pageContains ) === -1;
   };
+
+  function getApiRoute( name: string ) {
+    return routes.find( ( route: Route ) => route.name === name );
+  }
+
+  function getApiUrl( name: string ) {
+    return page.api_host + '/' + getApiRoute( name ).uri;
+  }
 
   function getAccountSetting( name: App.Enums.SiteSettingValue, defaultValue: any = null ) {
     return (
@@ -55,6 +75,7 @@ export function PageProvider< T extends PageData >( { page, children }: PageProv
         isPage,
         getAccountSetting,
         userProfileUrl,
+        getApiUrl,
       } }>
       { children }
     </PageContext.Provider>

--- a/client/Providers/SearchProvider.tsx
+++ b/client/Providers/SearchProvider.tsx
@@ -48,10 +48,10 @@ export const SearchProvider: FC< { children: React.ReactNode } > = ( { children 
   async function search( query: string ) {
     setQuery( query );
     setPending( true );
-    const res: AxiosResponse = await tryRequest( 'get', 'search_query', {
+    const { data } = await tryRequest( 'get', 'search_query', {
       query,
     } );
-    setResults( res.data );
+    setResults( data );
     setPending( false );
   }
 

--- a/client/Types/app.d.ts
+++ b/client/Types/app.d.ts
@@ -100,6 +100,17 @@ export type IntentData = {
 message: string;
 embedding?: Array<any>;
 };
+export type OAuthClientData = {
+client_id: string;
+client_secret: string;
+site_id: string;
+token: App.Data.OAuthClientTokenData;
+};
+export type OAuthClientTokenData = {
+access_token: string;
+token_type: string;
+expires_in: number;
+};
 export type PlanData = {
 name: string;
 slug: string;
@@ -237,7 +248,6 @@ statuses: Array<App.Data.DocIndexStatusData>;
 export type StoreUserRequestData = {
 user_request: App.Data.UserRequestData;
 stream_url: string;
-access_token: string;
 wp_user_id: number;
 site_id: string;
 };

--- a/client/Types/types.d.ts
+++ b/client/Types/types.d.ts
@@ -11,6 +11,12 @@ export type AWPRootType = HTMLElement & {
   ) => void;
 };
 
+export type WpResponse< T = any > = {
+  success: boolean;
+  data: T;
+  message?: string;
+};
+
 export interface PageData {
   nonce: string;
   wp_rest_nonce: string;

--- a/server/Client/ReactClient.php
+++ b/server/Client/ReactClient.php
@@ -196,7 +196,7 @@ abstract class ReactClient implements ClientAppInterface, Registrable
             'is_connected' => (bool) $access_token,
             'site_id' => $this->main->siteId(),
             'user' => $current_user,
-            'api_host' => $this->main->apiHost(),
+            'api_host' => $this->main->apiClientHost(),
             'account' => $this->main->client()->user(),
             'account_settings' => $this->main->accountSettings()->get(),
             'general_settings' => $this->main->settings->getGeneralSettings(),

--- a/server/Http/Controllers/AwpApi.php
+++ b/server/Http/Controllers/AwpApi.php
@@ -14,4 +14,13 @@ class AwpApi extends BaseController
 
         return $this->main->client()->$endpoint($params);
     }
+
+    public function createRequest()
+    {
+        $response = $this->main->client()->convoCreate($this->request->toArray());
+
+        $response['access_token'] = $this->main->auth()->getAccessToken();
+
+        $this->respond($response);
+    }
 }

--- a/server/Http/Controllers/ManuallyActivateAgent.php
+++ b/server/Http/Controllers/ManuallyActivateAgent.php
@@ -14,9 +14,7 @@ class ManuallyActivateAgent extends BaseController
         $data = json_decode(base64_decode($data['apiKey']), true);
 
         if (! $data['site_id'] || ! $data['client_id'] || ! $data['client_secret'] || ! $data['token']['access_token'] || ! $data['token']['expires_in']) {
-            $this->error([
-                'message' => 'Invalid data',
-            ]);
+            $this->error('failed_site_verification');
         }
 
         $this->main->settings->set([

--- a/server/Http/Controllers/OauthAuthorize.php
+++ b/server/Http/Controllers/OauthAuthorize.php
@@ -18,8 +18,6 @@ class OauthAuthorize extends BaseController
             'scope' => 'site_connection',
         ];
 
-        @ray($connect_url_query_strings);
-
         return ['url' => $this->main->apiHost().'/connect_site?'.http_build_query($connect_url_query_strings)];
     }
 }

--- a/server/Http/Controllers/SaveConnection.php
+++ b/server/Http/Controllers/SaveConnection.php
@@ -12,16 +12,13 @@ class SaveConnection extends BaseController
 
     public function __invoke(): void
     {
-
         $key = sanitize_text_field($_REQUEST['verification_key'] ?? '');
         if (
             ! $this->main->settings->verification_key
             || empty($key)
                && $key !== $this->main->settings->verification_key
         ) {
-            $this->error([
-                'status' => 'failed',
-            ]);
+            $this->error('failed_site_verification');
         }
 
         $this->main->settings->delete('verification_key');

--- a/server/Http/HttpErrors.php
+++ b/server/Http/HttpErrors.php
@@ -30,6 +30,10 @@ class HttpErrors
                 'message' => __('An unknown error occurred.', 'agentwp'),
                 'code' => 500,
             ],
+            'failed_site_verification' => [
+                'message' => __('Your site could not be verified.', 'agentwp'),
+                'code' => 403,
+            ],
         ];
     }
 

--- a/server/Modules/AwpClient/routes.json
+++ b/server/Modules/AwpClient/routes.json
@@ -272,5 +272,14 @@
             "HEAD"
         ],
         "name": "oauthConnectSite"
+    },
+    {
+        "key": "oauth.manually-connect-site",
+        "uri": "manually_connect_site",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "name": "oauthManuallyConnectSite"
     }
 ]

--- a/server/Page/Admin/Settings.php
+++ b/server/Page/Admin/Settings.php
@@ -79,17 +79,21 @@ class Settings extends ReactClient
 
         if ($screen->id === 'toplevel_page_'.$this->main::SETTINGS_PAGE && isset($_GET['code'])) {
             $code = sanitize_text_field($_GET['code']);
-            $response_raw = wp_remote_post($this->main->apiHost().'/oauth/token', [
-                'body' => [
-                    'grant_type' => 'authorization_code',
-                    'client_id' => $this->main->settings->client_id,
-                    'client_secret' => $this->main->settings->client_secret,
-                    'redirect_uri' => $this->main->settingsPageUrl,
-                    'code' => $code,
-                ],
+
+            $response = $this->main->client()->passportToken([
+                'grant_type' => 'authorization_code',
+                'client_id' => $this->main->settings->client_id,
+                'client_secret' => $this->main->settings->client_secret,
+                'redirect_uri' => $this->main->settingsPageUrl,
+                'code' => $code,
             ]);
 
-            $response = json_decode($response_raw['body'], true);
+            if (\is_wp_error($response)) {
+                wp_redirect($this->main->settingsPageUrl);
+                error_log(print_r($response, true));
+
+                return;
+            }
 
             $response['expires_in'] = $response['expires_in'] * 1000;
 

--- a/server/Registry/Router.php
+++ b/server/Registry/Router.php
@@ -35,6 +35,7 @@ class Router implements Registrable
 
     protected array $routes = [
         'api' => AwpApi::class,
+        'create_request' => [AwpApi::class, 'createRequest'],
         'test_auth' => TestAuthResponse::class,
         'test_route' => [TestResponse::class, 'successfulResponse'],
         'test_stream_forward' => [TestResponse::class, 'stream'],


### PR DESCRIPTION
- Added client side ApiRoutes under PageProvider so we can use URLs by names from `route.json`
- Added better typing around requests. `tryRequest` is now wrapped in WpResponse
- `convoCreate` goes through WP now so it can merge it's access token with the API response
  - Access Tokens by their nature can't be retrieved, only recreated on the backend, so returning it from the API isn't feasible
  - Instead, we just make the request through the proxy and add the `access_token` already stored in settings

## API Platform Changes
https://github.com/wpai-inc/awp/pull/250