### PR TITLE
Switch from custom Db class to $wpdb for database queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentwp",
-  "version": "0.3.5",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentwp",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
         "@material-design-icons/svg": "^0.14.13",

--- a/server/Http/Controllers/QueryActionController.php
+++ b/server/Http/Controllers/QueryActionController.php
@@ -2,99 +2,97 @@
 
 namespace WpAi\AgentWp\Http\Controllers;
 
-// use WpAi\AgentWp\Services\Db;
-
 class QueryActionController extends BaseController
 {
     public function __invoke(): void
     {
-        // if (! $this->main->auth->canAccessDB()) {
-        //     $this->error('access_denied');
-        //     exit;
-        // }
+        if (! $this->main->auth->canAccessDB()) {
+            $this->error('access_denied');
+            exit;
+        }
 
-        // global $wpdb;
+        global $wpdb;
 
-        // // unescape slashes
-        // $sql = stripslashes($this->request->get('sql'));
-        // $sql = $this->filterSqlQuery($sql);
+        // unescape slashes
+        $sql = stripslashes($this->request->get('sql'));
+        $sql = $this->filterSqlQuery($sql);
 
-        // $args = $this->request->all('args') ?: [];
+        $args = $this->request->all('args') ?: [];
 
-        // $results = Db::getResults($sql, $args);
+        $results = $wpdb->get_results($wpdb->prepare($sql, $args), ARRAY_A);
 
-        // if ($wpdb->last_error) {
-        //     $this->respondWithError($wpdb->last_error, 422);
-        // } else {
-        //     $this->respond([
-        //         'results' => $results,
-        //     ]);
-        // }
+        if ($wpdb->last_error) {
+            $this->respondWithError($wpdb->last_error, 422);
+        } else {
+            $this->respond([
+                'results' => $results,
+            ]);
+        }
     }
 
-    // private function filterSqlQuery($sql)
-    // {
-    //     // Convert the query to uppercase for case-insensitive matching
-    //     $uppercaseSQL = strtoupper($sql);
+    private function filterSqlQuery($sql)
+    {
+        // Convert the query to uppercase for case-insensitive matching
+        $uppercaseSQL = strtoupper($sql);
 
-    //     // List of disallowed keywords
-    //     $disallowedKeywords = [
-    //         'INSERT',
-    //         'UPDATE',
-    //         'DELETE',
-    //         'TRUNCATE',
-    //         'REPLACE',
-    //         'DROP',
-    //         'ALTER',
-    //         'CREATE',
-    //         'GRANT',
-    //         'REVOKE',
-    //         'LOCK',
-    //         'UNLOCK',
-    //         'LOAD DATA',
-    //         'MERGE',
-    //         'SET',
-    //         'CALL',
-    //         'EXECUTE',
-    //         'DO',
-    //         'HANDLER',
-    //         'RENAME',
-    //         'ANALYZE',
-    //         'OPTIMIZE',
-    //         'REPAIR',
-    //         'BACKUP',
-    //         'RESTORE',
-    //         'PURGE',
-    //         'RESET',
-    //         'START',
-    //         'STOP',
-    //         'COMMIT',
-    //         'ROLLBACK',
-    //         'SAVEPOINT',
-    //     ];
+        // List of disallowed keywords
+        $disallowedKeywords = [
+            'INSERT',
+            'UPDATE',
+            'DELETE',
+            'TRUNCATE',
+            'REPLACE',
+            'DROP',
+            'ALTER',
+            'CREATE',
+            'GRANT',
+            'REVOKE',
+            'LOCK',
+            'UNLOCK',
+            'LOAD DATA',
+            'MERGE',
+            'SET',
+            'CALL',
+            'EXECUTE',
+            'DO',
+            'HANDLER',
+            'RENAME',
+            'ANALYZE',
+            'OPTIMIZE',
+            'REPAIR',
+            'BACKUP',
+            'RESTORE',
+            'PURGE',
+            'RESET',
+            'START',
+            'STOP',
+            'COMMIT',
+            'ROLLBACK',
+            'SAVEPOINT',
+        ];
+        $foundDisallowedKeywords = [];
+        // Check for disallowed keywords
+        foreach ($disallowedKeywords as $keyword) {
+            if (preg_match('/\b'.preg_quote($keyword, '/').'\b/', $uppercaseSQL)) {
+                $foundDisallowedKeywords[] = $keyword;
+            }
+        }
 
-    //     // Check for disallowed keywords
-    //     foreach ($disallowedKeywords as $keyword) {
-    //         if (strpos($uppercaseSQL, $keyword) !== false) {
-    //             $disallowedKeywords[] = $keyword;
-    //         }
-    //     }
+        if (! empty($foundDisallowedKeywords)) {
+            // Translators: %1$s is a list of disallowed SQL keywords found in the query.
+            throw new \Exception(esc_html(printf(__('Query contains disallowed keyword: %1$s', 'agentwp'), implode(', ', $foundDisallowedKeywords))));
+        }
 
-    //     if (! empty($disallowedKeywords)) {
-    //         // Translators: %1$s is a list of disallowed SQL keywords found in the query.
-    //         throw new \Exception(esc_html(printf(__('Query contains disallowed keyword: %1$s', 'agentwp'), implode(', ', $disallowedKeywords))));
-    //     }
+        // Additional checks
+        if (preg_match('/;\s*\w/', $sql)) {
+            throw new \Exception(esc_html__('Multiple statements are not allowed', 'agentwp'));
+        }
 
-    //     // Additional checks
-    //     if (preg_match('/;\s*\w/', $sql)) {
-    //         throw new \Exception(esc_html__('Multiple statements are not allowed', 'agentwp'));
-    //     }
+        if (! preg_match('/^\s*SELECT\b/i', $sql)) {
+            throw new \Exception(esc_html__('Query must start with SELECT', 'agentwp'));
+        }
 
-    //     if (! preg_match('/^\s*SELECT\b/i', $sql)) {
-    //         throw new \Exception(esc_html__('Query must start with SELECT', 'agentwp'));
-    //     }
-
-    //     // If all checks pass, return the original query
-    //     return $sql;
-    // }
+        // If all checks pass, return the original query
+        return $sql;
+    }
 }

--- a/server/Installer.php
+++ b/server/Installer.php
@@ -6,7 +6,6 @@ use WpAi\AgentWp\Contracts\Registrable;
 use WpAi\AgentWp\Modules\Summarization\SiteSummarizer;
 use WpAi\AgentWp\Registry\IndexSiteData;
 use WpAi\AgentWp\Registry\IndexSiteSummary;
-use WpAi\AgentWp\Services\Db;
 
 /**
  * Handles the plugin activation, deactivation, and uninstallation.
@@ -61,20 +60,21 @@ class Installer implements Registrable
 
     public function cleanup_plugin_data()
     {
+        global $wpdb;
         $key = Main::SLUG;
         $this->main->settings->delete('general_settings');
         delete_option($key.'_summary');
         delete_option($key.'_site_summary');
         delete_option($key.'_site_data');
         delete_option($key.'_site_theme_json');
-        global $wpdb;
 
-        Db::query(
-            "DELETE FROM $wpdb->options WHERE option_name LIKE %s AND option_name LIKE %s",
-            [
+        $wpdb->query(
+            $wpdb->prepare("DELETE FROM $wpdb->options WHERE option_name LIKE %s AND option_name LIKE %s", [
                 '%'.$wpdb->esc_like($key).'%',
                 '%_transient%',
-            ]);
+            ])
+        );
+
     }
 
     public function redirect(): void

--- a/server/Modules/SiteDocs/DocPost.php
+++ b/server/Modules/SiteDocs/DocPost.php
@@ -3,7 +3,6 @@
 namespace WpAi\AgentWp\Modules\SiteDocs;
 
 use DateTime;
-use WpAi\AgentWp\Services\Db;
 
 class DocPost extends Doc
 {
@@ -66,30 +65,36 @@ class DocPost extends Doc
     {
         global $wpdb;
 
-        return Db::getResults("
-            SELECT p.ID, p.post_parent, p.post_date, p.post_modified, p.post_title, p.post_content
-            FROM {$wpdb->posts} p
-            WHERE p.post_type = %s AND p.post_status = %s
-            AND p.ID > %d
-            ORDER BY p.ID ASC
-            LIMIT %d
-        ", [
-            'post',
-            'publish',
-            $last_doc_id_indexed,
-            $batch_amount,
-        ]);
+        return $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT p.ID, p.post_parent, p.post_date, p.post_modified, p.post_title, p.post_content
+                FROM {$wpdb->posts} p
+                WHERE p.post_type = %s AND p.post_status = %s
+                AND p.ID > %d
+                ORDER BY p.ID ASC
+                LIMIT %d",
+                [
+                    'post',
+                    'publish',
+                    $last_doc_id_indexed,
+                    $batch_amount,
+                ]
+            )
+        );
     }
 
     private function getPostMeta(int $postId): array
     {
         global $wpdb;
 
-        $meta = Db::getResults("
-            SELECT meta_id, meta_key, meta_value
-            FROM {$wpdb->postmeta}
-            WHERE post_id = %d
-        ", [$postId]);
+        $meta = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT meta_id, meta_key, meta_value
+                FROM {$wpdb->postmeta}
+                WHERE post_id = %d",
+                [$postId]
+            )
+        );
 
         return array_map(function ($meta) {
             return [
@@ -104,11 +109,14 @@ class DocPost extends Doc
     {
         global $wpdb;
 
-        $comments = Db::getResults("
-            SELECT comment_ID, comment_content
-            FROM {$wpdb->comments}
-            WHERE comment_post_ID = %d
-        ", [$postId]);
+        $comments = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT comment_ID, comment_content
+                FROM {$wpdb->comments}
+                WHERE comment_post_ID = %d",
+                [$postId]
+            )
+        );
 
         return array_map(function ($comment) {
             return [

--- a/server/Registry/IndexSiteData.php
+++ b/server/Registry/IndexSiteData.php
@@ -5,7 +5,6 @@ namespace WpAi\AgentWp\Registry;
 use WpAi\AgentWp\Contracts\Cacheable;
 use WpAi\AgentWp\Contracts\Registrable;
 use WpAi\AgentWp\Main;
-use WpAi\AgentWp\Services\Db;
 use WpAi\AgentWp\SiteData;
 use WpAi\AgentWp\Traits\HasCache;
 use WpAi\AgentWp\Traits\HasScheduler;
@@ -107,6 +106,7 @@ class IndexSiteData implements Cacheable, Registrable
 
     public function add_db_schema_to_debug_info($info): array
     {
+        global $wpdb;
         /**
          * Dont add db schema if it's disabled.
          */
@@ -114,10 +114,11 @@ class IndexSiteData implements Cacheable, Registrable
             return $info;
         }
 
-        $tables = Db::getResults('SHOW TABLES', [], ARRAY_N);
+        $tables = $wpdb->get_results('SHOW TABLES', ARRAY_N);
+
         $tables = array_map('current', $tables);
         foreach ($tables as $table) {
-            $rows = Db::getResults('DESCRIBE '.$table, [], ARRAY_A);
+            $rows = $wpdb->get_results('DESCRIBE '.$table, ARRAY_A);
             $header = array_keys($rows[0]);
             array_unshift($rows, $header);
             $info['db-schema']['tables'][$table] = array_map(function ($row) {


### PR DESCRIPTION
Refactor database interactions to use the global $wpdb object instead of the custom Db class for consistency and integration with WordPress standards. This change affects multiple files, enhancing maintainability and compatibility with WordPress updates.