### PR TITLE
Added canUpdate to settings and removed accountSettings caching

### DIFF
--- a/client/Page/Admin/Chat/Partials/ConvoOnlyToggle.tsx
+++ b/client/Page/Admin/Chat/Partials/ConvoOnlyToggle.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { usePage } from '@/Providers/PageProvider';
 import { useRestRequest } from '@/Providers/RestRequestProvider';
 import { optimistic } from '@/lib/utils';
+import { AgentTooltip } from '@/Components/ui/tooltip';
 
 export default function ConvoOnlyToggle() {
   const { getAccountSetting } = usePage();
@@ -21,10 +22,23 @@ export default function ConvoOnlyToggle() {
     );
   }
 
-  return (
+  return setting?.canUpdate ? (
     <label className="flex items-center gap-1.5">
       <ChatSwitch checked={ enabled } onCheckedChange={ handleChange } />
       Convo Only
     </label>
+  ) : (
+    <AgentTooltip
+      content={
+        <p>
+          Agentic actions are currently disabled and will roll out in the coming weeks.{ ' ' }
+          <a href="https://agentwp.com/kb/convo-only-mode/">More info</a>
+        </p>
+      }>
+      <label className="flex items-center gap-1.5 opacity-75 cursor-not-allowed">
+        <ChatSwitch checked={ enabled } disabled={ ! setting?.canUpdate } />
+        Convo Only
+      </label>
+    </AgentTooltip>
   );
 }

--- a/client/Types/app.d.ts
+++ b/client/Types/app.d.ts
@@ -6,6 +6,8 @@ recipeConfidence: number;
 complexity: number;
 capabilityMatch: number;
 continuedConvo: boolean;
+canAnswerDirectly: boolean;
+shouldQuery: boolean;
 convoOnly: boolean;
 visionEnabled: boolean;
 shouldNavigate: number;
@@ -34,6 +36,7 @@ result: Array<any> | null;
 recipe_idx: number | null;
 final: boolean;
 hasExecuted: boolean;
+hasError: boolean;
 };
 export type AgentActionResultData = {
 status: App.Enums.AgentActionResultStatus;
@@ -151,6 +154,7 @@ export type SiteSettingData = {
 name: App.Enums.SiteSettingValue;
 value: any;
 label: string | null;
+canUpdate: boolean | null;
 };
 export type SiteSupportRequestData = {
 type: string;

--- a/server/Services/AccountSettings.php
+++ b/server/Services/AccountSettings.php
@@ -8,8 +8,6 @@ class AccountSettings
 {
     private WpAwpClient $client;
 
-    private int $site_settings_expiration = 60;
-
     public function __construct(WpAwpClient $client)
     {
         $this->client = $client;
@@ -17,11 +15,7 @@ class AccountSettings
 
     public function get()
     {
-        if (false !== ($res = get_transient('site_settings'))) {
-            return $res;
-        }
         $res = $this->client->siteSettingAll();
-        set_transient('site_settings', $res, $this->site_settings_expiration);
 
         return is_array($res) ? $res : [];
     }


### PR DESCRIPTION
- adds a `canUpdate` property
- removes caching from `$main->accountSettings()` – no longer needed since the extra calls are fixed