### PR TITLE
Add X-Wp-Plugin-Version header to API requests

### DIFF
--- a/server/Modules/AwpClient/Client.php
+++ b/server/Modules/AwpClient/Client.php
@@ -5,6 +5,7 @@ namespace WpAi\AgentWp\Modules\AwpClient;
 use GuzzleHttp\Client as GuzzleHttpClient;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
+use WpAi\AgentWp\Main;
 
 class Client
 {
@@ -132,6 +133,7 @@ class Client
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
             'X-Wp-Agent-Version' => $this->version,
+            'X-Wp-Plugin-Version' => Main::PLUGIN_VERSION,
         ];
 
         if ($this->wpUser) {


### PR DESCRIPTION
Incorporated the plugin version into the API request headers by utilizing Main::PLUGIN_VERSION. This ensures the server can identify the client plugin version for better compatibility and debugging.