### PR TITLE
ENG-2048: Add method to remove capabilities for all users

### DIFF
--- a/server/Installer.php
+++ b/server/Installer.php
@@ -54,6 +54,7 @@ class Installer implements Registrable
         IndexSiteSummary::clearSchedules(['autoUpdate']);
 
         if ($this->main->settings->get('general_settings.cleanup_after_deactivate') !== false) {
+            $this->main->auth()->removeCapabilitiesFromAllUsers();
             $this->main->settings->disconnectSite($this->main);
             $this->cleanup_plugin_data();
         }

--- a/server/UserAuth.php
+++ b/server/UserAuth.php
@@ -147,7 +147,26 @@ class UserAuth
 
     public function removeCapabilitiesFromAllUsers(): void
     {
-        $users = get_users();
+        $users = get_users([
+            'meta_query' => [
+                'relation' => 'OR',
+                [
+                    'key' => $this->user->cap_key,
+                    'value' => self::CAP_AGENTWP_ACCESS,
+                    'compare' => 'LIKE',
+                ],
+                [
+                    'key' => $this->user->cap_key,
+                    'value' => self::CAP_MANAGE_AGENTWP_CONNECTION,
+                    'compare' => 'LIKE',
+                ],
+                [
+                    'key' => $this->user->cap_key,
+                    'value' => self::CAP_MANAGE_AGENTWP_USERS,
+                    'compare' => 'LIKE',
+                ],
+            ],
+        ]);
 
         foreach ($users as $user) {
             $this->removeUserCapabilities($user);

--- a/server/UserAuth.php
+++ b/server/UserAuth.php
@@ -136,6 +136,24 @@ class UserAuth
         $this->user->add_cap($cap);
     }
 
+    public function removeUserCapabilities(?WP_User $user = null): void
+    {
+        $user = $user ?? $this->user;
+
+        $user->remove_cap(self::CAP_MANAGE_AGENTWP_CONNECTION);
+        $user->remove_cap(self::CAP_MANAGE_AGENTWP_USERS);
+        $user->remove_cap(self::CAP_AGENTWP_ACCESS);
+    }
+
+    public function removeCapabilitiesFromAllUsers(): void
+    {
+        $users = get_users();
+
+        foreach ($users as $user) {
+            $this->removeUserCapabilities($user);
+        }
+    }
+
     public function removeCap(string $cap): void
     {
         $this->user->remove_cap($cap);


### PR DESCRIPTION
Introduced new methods in UserAuth to remove specific capabilities from individual and all users. Updated the Installer to call these methods during plugin deactivation for cleanup purposes.

This does not resolve the problem, it is just an improvement of deactivate function.