### PR TITLE
ENG: 2020: Fix tooltips not being displayed on the right place

### DIFF
--- a/client/Components/Chat/MessageBox/partials/ToggleVision.tsx
+++ b/client/Components/Chat/MessageBox/partials/ToggleVision.tsx
@@ -35,7 +35,7 @@ export default function ToggleVision() {
   }
 
   return (
-    <AgentTooltip content={ <p className="max-w-60">{ msg }</p> }>
+    <AgentTooltip content={ msg } maxWidth={ 250 }>
       <button
         type="button"
         onClick={ toggleVision }

--- a/client/Components/Chat/StaticChat.tsx
+++ b/client/Components/Chat/StaticChat.tsx
@@ -7,7 +7,7 @@ export default function StaticChat() {
     <HotKeyProvider>
       <ChatContainer
         id="agentwp-settings-chat"
-        className="relative h-full max-h-screen min-w-[400px] w-full @container">
+        className="relative h-full max-h-screen min-w-[400px] w-full @container translate-x-0 translate-y-0">
         <ChatCore />
       </ChatContainer>
     </HotKeyProvider>


### PR DESCRIPTION
@content is adding `container-type: inline-size;` which is making the tooltip position not being dsiplaied on the right place. The solution is to add a transform translate x-0 y-0. Updated `ToggleVision.tsx` to simplify tooltip content and set a fixed maxWidth.